### PR TITLE
fix: change ecommerce API call

### DIFF
--- a/src/order-history/service.js
+++ b/src/order-history/service.js
@@ -3,18 +3,18 @@ import { getConfig } from '@edx/frontend-platform';
 
 // eslint-disable-next-line import/prefer-default-export
 export async function getOrders(page = 1, pageSize = 20) {
-  const { ORDER_HISTORY_URL, RECEIPT_URL, ECOMMERCE_BASE_URL } = getConfig();
+  const { ORDER_HISTORY_API_URL, RECEIPT_URL, ECOMMERCE_BASE_URL } = getConfig();
   
   const ECOMMERCE_API_BASE_URL = `${ECOMMERCE_BASE_URL}/api/v2`;
   const ECOMMERCE_RECEIPT_BASE_URL = RECEIPT_URL
     ? `${RECEIPT_URL}` : `${ECOMMERCE_BASE_URL}/checkout/receipt/`;
-  const ECOMMERCE_ORDERS_URL = ORDER_HISTORY_URL
-    ? `${ORDER_HISTORY_URL}` : `${ECOMMERCE_API_BASE_URL}/orders/`;
+  const ECOMMERCE_ORDERS_API_URL = ORDER_HISTORY_API_URL
+    ? `${ORDER_HISTORY_API_URL}` : `${ECOMMERCE_API_BASE_URL}/orders/`;
 
   const httpClient = getAuthenticatedHttpClient();
   const { username } = getAuthenticatedUser();
 
-  const { data } = await httpClient.get(`${ECOMMERCE_ORDERS_URL}`, {
+  const { data } = await httpClient.get(`${ECOMMERCE_ORDERS_API_URL}`, {
     params: {
       username,
       page,


### PR DESCRIPTION
The `ORDER_HISTORY_URL` config was being used for main menu configuration and also to configure the Ecommerce orders API URL. So this change changes the API URL to other config name.

fccn/nau-technical#559
