### PR TITLE
Payments flow adaptation for lazy payments

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "url": "git+https://github.com/openedx/frontend-app-ecommerce.git"
   },
   "scripts": {
-    "build": "fedx-scripts webpack",
+    "build": "PUBLIC_PATH=/orders/ fedx-scripts webpack",
     "i18n_extract": "fedx-scripts formatjs extract",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
-    "start": "fedx-scripts webpack-dev-server --progress",
-    "dev": "PUBLIC_PATH=/ecommerce/ MFE_CONFIG_API_URL='http://local.openedx.io:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
+    "start": "PUBLIC_PATH=/orders/ fedx-scripts webpack-dev-server --progress",
+    "dev": "PUBLIC_PATH=/orders/ MFE_CONFIG_API_URL='http://local.openedx.io:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "fedx-scripts jest --coverage"
   },
   "author": "edX",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -21,6 +21,7 @@ import configureStore from './store';
 import { NotFoundPage } from './components';
 import { OrdersAndSubscriptionsPage } from './orders-and-subscriptions';
 import { ManageSubscriptionsPage } from './subscriptions';
+import ThankYouPage from './thank-you';
 
 import './index.scss';
 
@@ -59,6 +60,7 @@ subscribe(APP_READY, () => {
             />
           ) : null}
           <Route path="/orders" element={<OrdersAndSubscriptionsPage />} />
+          <Route path="/thank-you" element={<ThankYouPage />} />
           <Route path="/notfound" element={<NotFoundPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -8,7 +8,10 @@ import {
   FormattedDate,
   FormattedNumber,
 } from '@edx/frontend-platform/i18n';
-import { DataTable, Hyperlink, Pagination } from '@openedx/paragon';
+import {
+  Badge, DataTable, Hyperlink, Pagination,
+} from '@openedx/paragon';
+import { Receipt } from '@openedx/paragon/icons';
 import MediaQuery from 'react-responsive';
 
 import { PageLoading } from '../components';
@@ -18,6 +21,8 @@ import messages from './OrderHistoryPage.messages';
 // Actions
 import { fetchOrders } from './actions';
 import { pageSelector } from './selectors';
+import { fetchOrderPaymentStatus } from './service';
+import { isPaid, isPending, statusPresentation } from './orderStatus';
 
 /**
  * TEMPORARY
@@ -37,6 +42,19 @@ class OrderHistoryPage extends React.Component {
     super(props);
 
     this.handlePageSelect = this.handlePageSelect.bind(this);
+    this.state = {
+      statusOverrides: {},
+    };
+  }
+
+  componentDidMount() {
+    this.resolvePendingOrders();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.orders !== this.props.orders) {
+      this.resolvePendingOrders();
+    }
   }
 
   handlePageSelect(page) {
@@ -44,26 +62,77 @@ class OrderHistoryPage extends React.Component {
     this.props.fetchOrders(page);
   }
 
+  getStatus(order) {
+    return this.state.statusOverrides[order.orderId] || order.status;
+  }
+
   getTableData() {
-    return this.props.orders.map(({
-      lineItems,
-      datePlaced,
-      total,
-      currency,
-      orderId,
-      receiptUrl,
-    }) => ({
-      description: this.renderLineItems(lineItems),
-      datePlaced: <FormattedDate value={new Date(datePlaced)} />,
-      // eslint-disable-next-line react/style-prop-object
-      total: <FormattedNumber value={total} style="currency" currency={currency} />,
-      receiptUrl: (
-        <Hyperlink destination={receiptUrl}>
-          {this.props.intl.formatMessage(messages['ecommerce.order.history.view.order.detail'])}
-        </Hyperlink>
-      ),
-      orderId,
-    }), this);
+    return this.props.orders.map((order) => {
+      const {
+        lineItems,
+        datePlaced,
+        total,
+        currency,
+        orderId,
+        receiptUrl,
+      } = order;
+      const status = this.getStatus(order);
+      return {
+        description: this.renderLineItems(lineItems),
+        datePlaced: <FormattedDate value={new Date(datePlaced)} />,
+        // eslint-disable-next-line react/style-prop-object
+        total: <FormattedNumber value={total} style="currency" currency={currency} />,
+        status: this.renderStatusBadge(status),
+        orderId,
+        receipt: (isPaid(status) && receiptUrl) ? this.renderReceiptIcon(receiptUrl) : null,
+      };
+    }, this);
+  }
+
+  /**
+   * Resolve every pending order on the current page.
+   *
+   * This is the whole asynchronous-payment mechanism: there is no polling and no
+   * background job. Opening this page asks ecommerce, once per pending order,
+   * whether PayGate has received the payment yet. An order that has been paid is
+   * fulfilled server-side during that call and comes back as `Complete`.
+   */
+  async resolvePendingOrders() {
+    const pending = (this.props.orders || []).filter(order => isPending(this.getStatus(order)));
+
+    await Promise.all(pending.map(async (order) => {
+      const data = await fetchOrderPaymentStatus(order.orderId);
+      if (!data || !data.status) { return; }
+      this.setState(prev => ({
+        statusOverrides: {
+          ...prev.statusOverrides,
+          [order.orderId]: data.status,
+        },
+      }));
+    }));
+  }
+
+  renderStatusBadge(status) {
+    const { messageKey, variant } = statusPresentation(status);
+    return (
+      <Badge variant={variant} data-testid={`order-status-${variant}`}>
+        {this.props.intl.formatMessage(messages[messageKey])}
+      </Badge>
+    );
+  }
+
+  renderReceiptIcon(receiptUrl) {
+    // Use the project's Paragon icon set instead of an inline SVG
+    return (
+      <Hyperlink
+        destination={receiptUrl}
+        className="order-receipt-link"
+        data-testid="order-receipt-link"
+        aria-label={this.props.intl.formatMessage(messages['ecommerce.order.history.view.order.detail'])}
+      >
+        <Receipt size={16} aria-hidden />
+      </Hyperlink>
+    );
   }
 
   renderPagination() {
@@ -120,8 +189,16 @@ class OrderHistoryPage extends React.Component {
             accessor: 'orderId',
           },
           {
-            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.details']),
-            accessor: 'receiptUrl',
+            Header: this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.status']),
+            accessor: 'status',
+          },
+          {
+            Header: '',
+            accessor: 'receipt',
+            // ensure this column is right aligned in styles
+            headerClassName: 'text-right',
+            className: 'text-right',
+            width: 50,
           },
         ]}
       >
@@ -132,7 +209,7 @@ class OrderHistoryPage extends React.Component {
 
   renderMobileOrdersTable() {
     return this.getTableData().map(({
-      description, datePlaced, total, orderId, receiptUrl,
+      description, datePlaced, total, orderId, status, receipt,
     }) => (
       <div className="border-bottom py-3" key={orderId}>
         <dl>
@@ -152,8 +229,12 @@ class OrderHistoryPage extends React.Component {
             {this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.order.number'])}
           </dt>
           <dd>{orderId}</dd>
+          <dt>
+            {this.props.intl.formatMessage(messages['ecommerce.order.history.table.column.status'])}
+          </dt>
+          <dd>{status}</dd>
+          <dd className="text-right">{receipt}</dd>
         </dl>
-        <p>{receiptUrl}</p>
       </div>
     ));
   }
@@ -221,6 +302,7 @@ OrderHistoryPage.propTypes = {
     orderId: PropTypes.string,
     receiptUrl: PropTypes.string,
     currency: PropTypes.string,
+    status: PropTypes.string,
     lineItems: PropTypes.arrayOf(PropTypes.shape({
       title: PropTypes.string,
       quantity: PropTypes.number,

--- a/src/order-history/OrderHistoryPage.messages.jsx
+++ b/src/order-history/OrderHistoryPage.messages.jsx
@@ -46,6 +46,35 @@ const messages = defineMessages({
     defaultMessage: 'Order details',
     description: 'The column label for Order details in the order history table.',
   },
+  'ecommerce.order.history.table.column.status': {
+    id: 'ecommerce.order.history.table.column.status',
+    defaultMessage: 'Status',
+    description: 'The column label for the payment status of the order in the order history table.',
+  },
+  'ecommerce.order.history.status.paid': {
+    id: 'ecommerce.order.history.status.paid',
+    defaultMessage: 'Paid',
+    description: 'Status label displayed for an order whose payment is confirmed.',
+  },
+  'ecommerce.order.history.status.pending': {
+    id: 'ecommerce.order.history.status.pending',
+    defaultMessage: 'Awaiting payment',
+    description:
+      'Status label displayed for an order whose payment has not been confirmed '
+      + 'yet, such as an unpaid Multibanco reference.',
+  },
+  'ecommerce.order.history.status.failed': {
+    id: 'ecommerce.order.history.status.failed',
+    defaultMessage: 'Payment failed',
+    description: 'Status label displayed for an order whose payment failed.',
+  },
+  'ecommerce.order.history.status.fulfillment.error': {
+    id: 'ecommerce.order.history.status.fulfillment.error',
+    defaultMessage: 'Paid, enrolment pending',
+    description:
+      'Status label displayed for an order that has been paid but whose enrolment '
+      + 'could not be completed yet.',
+  },
 });
 
 export default messages;

--- a/src/order-history/OrderHistoryPage.test.jsx
+++ b/src/order-history/OrderHistoryPage.test.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable global-require */
 import React from 'react';
-import { render } from '../testing';
+import { render, screen, waitFor } from '../testing';
 
 import ConnectedOrderHistoryPage from './OrderHistoryPage';
+import * as service from './service';
 
 const storeMocks = require('../store/__mocks__/mockStore');
 
@@ -17,7 +18,19 @@ const requiredOrderHistoryPageProps = {
 global.matchMedia = (media) => ({
   addListener: () => {},
   removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
   matches: true,
+});
+
+// Mock react-responsive to always render children
+jest.mock('react-responsive', () => {
+  const react = require('react'); // eslint-disable-line global-require
+  return {
+    __esModule: true,
+    default: ({ children }) => react.createElement(react.Fragment, null, children),
+    useMediaQuery: () => true,
+  };
 });
 
 const matchSnapshot = (store) => {
@@ -29,6 +42,13 @@ const matchSnapshot = (store) => {
 };
 
 describe('<OrderHistoryPage />', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(service, 'fetchOrderPaymentStatus')
+      .mockResolvedValue(null);
+  });
+  afterEach(() => { jest.restoreAllMocks(); });
+
   describe('Renders correctly in various states', () => {
     it('renders orders table with pagination', () => {
       matchSnapshot(storeMocks);
@@ -64,6 +84,122 @@ describe('<OrderHistoryPage />', () => {
       };
 
       matchSnapshot(storeMockWithLoading);
+    });
+  });
+
+  describe('Asynchronous payment status', () => {
+    const storeWithOneOrder = (overrides = {}) => ({
+      ...storeMocks,
+      orderHistory: {
+        ...storeMocks.orderHistory,
+        loading: false,
+        loadingError: false,
+        count: 1,
+        pageCount: 1,
+        currentPage: 1,
+        orders: [{
+          datePlaced: '2026-05-07T00:39:20Z',
+          total: '5.00',
+          orderId: 'OPENEDX-100120',
+          currency: 'EUR',
+          lineItems: [{
+            title: 'Lugar em Teste',
+            quantity: 1,
+            description: 'Lugar em Teste',
+          }],
+          receiptUrl: 'http://example.com/checkout/receipt/?order_number=OPENEDX-100120',
+          status: 'Complete',
+          ...overrides,
+        }],
+      },
+    });
+
+    it('shows a pending order as awaiting payment, with no receipt link', async () => {
+      render(
+        <ConnectedOrderHistoryPage {...requiredOrderHistoryPageProps} />,
+        storeWithOneOrder({ status: 'Pending' }),
+      );
+
+      await waitFor(() => {
+        expect(service.fetchOrderPaymentStatus).toHaveBeenCalledWith('OPENEDX-100120');
+      });
+      expect(screen.getAllByTestId('order-status-warning').length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/awaiting payment/i).length).toBeGreaterThan(0);
+      // An unpaid order must not offer a receipt.
+      expect(screen.queryByTestId('order-receipt-link')).toBeNull();
+    });
+
+    it('shows a completed order as paid, with a receipt link', async () => {
+      render(
+        <ConnectedOrderHistoryPage {...requiredOrderHistoryPageProps} />,
+        storeWithOneOrder({ status: 'Complete' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('order-receipt-link').length).toBeGreaterThan(0);
+      });
+      expect(screen.getAllByTestId('order-receipt-link')[0]).toHaveAttribute(
+        'href',
+        'http://example.com/checkout/receipt/?order_number=OPENEDX-100120',
+      );
+    });
+
+    it('never asks the payment processor about an order that is already settled', async () => {
+      render(
+        <ConnectedOrderHistoryPage {...requiredOrderHistoryPageProps} />,
+        storeWithOneOrder({ status: 'Complete' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('order-receipt-link').length).toBeGreaterThan(0);
+      });
+      expect(service.fetchOrderPaymentStatus).not.toHaveBeenCalled();
+    });
+
+    it('updates a pending order to paid once PayGate confirms the payment', async () => {
+      service.fetchOrderPaymentStatus.mockResolvedValueOnce({
+        order_number: 'OPENEDX-100120',
+        status: 'Complete',
+      });
+
+      render(
+        <ConnectedOrderHistoryPage {...requiredOrderHistoryPageProps} />,
+        storeWithOneOrder({ status: 'Pending' }),
+      );
+
+      // The row starts pending and becomes paid, exposing the receipt link.
+      await waitFor(() => {
+        expect(screen.getAllByTestId('order-receipt-link').length).toBeGreaterThan(0);
+      });
+      expect(screen.getAllByTestId('order-status-success').length).toBeGreaterThan(0);
+      expect(screen.queryByTestId('order-status-warning')).toBeNull();
+    });
+
+    it('leaves the order pending when the status could not be resolved', async () => {
+      service.fetchOrderPaymentStatus.mockResolvedValueOnce(null);
+
+      render(
+        <ConnectedOrderHistoryPage {...requiredOrderHistoryPageProps} />,
+        storeWithOneOrder({ status: 'Pending' }),
+      );
+
+      await waitFor(() => {
+        expect(service.fetchOrderPaymentStatus).toHaveBeenCalled();
+      });
+      expect(screen.getAllByTestId('order-status-warning').length).toBeGreaterThan(0);
+    });
+
+    it('shows a failed payment as such', async () => {
+      render(
+        <ConnectedOrderHistoryPage {...requiredOrderHistoryPageProps} />,
+        storeWithOneOrder({ status: 'Payment Error' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('order-status-danger').length).toBeGreaterThan(0);
+      });
+      expect(screen.getAllByText(/payment failed/i).length).toBeGreaterThan(0);
+      expect(screen.queryByTestId('order-receipt-link')).toBeNull();
     });
   });
 });

--- a/src/order-history/__snapshots__/OrderHistoryPage.test.jsx.snap
+++ b/src/order-history/__snapshots__/OrderHistoryPage.test.jsx.snap
@@ -52,6 +52,444 @@ exports[`<OrderHistoryPage /> Renders correctly in various states renders orders
     Order History
   </h1>
   <div>
+    <div
+      class="border-bottom py-3"
+    >
+      <dl>
+        <dt>
+          Items
+        </dt>
+        <dd>
+          <p
+            class="d-flex"
+          >
+            <span
+              class="mr-3"
+            >
+              1
+              ×
+            </span>
+            <span>
+              Seat in Introduction to Urology with honor certificate
+            </span>
+          </p>
+        </dd>
+        <dt>
+          Date placed
+        </dt>
+        <dd>
+          1/26/2016
+        </dd>
+        <dt>
+          Total cost
+        </dt>
+        <dd>
+          $0.00
+        </dd>
+        <dt>
+          Order number
+        </dt>
+        <dd>
+          EDX-101706
+        </dd>
+        <dt>
+          Status
+        </dt>
+        <dd>
+          <span
+            class="badge badge-success"
+            data-testid="order-status-success"
+          >
+            Paid
+          </span>
+        </dd>
+        <dd
+          class="text-right"
+        />
+      </dl>
+    </div>
+    <div
+      class="border-bottom py-3"
+    >
+      <dl>
+        <dt>
+          Items
+        </dt>
+        <dd>
+          <p
+            class="d-flex"
+          >
+            <span
+              class="mr-3"
+            >
+              1
+              ×
+            </span>
+            <span>
+              Seat in "Dracula" by Stoker: BerkeleyX Book Club with honor certificate
+            </span>
+          </p>
+        </dd>
+        <dt>
+          Date placed
+        </dt>
+        <dd>
+          12/2/2015
+        </dd>
+        <dt>
+          Total cost
+        </dt>
+        <dd>
+          $0.00
+        </dd>
+        <dt>
+          Order number
+        </dt>
+        <dd>
+          EDX-101403
+        </dd>
+        <dt>
+          Status
+        </dt>
+        <dd>
+          <span
+            class="badge badge-success"
+            data-testid="order-status-success"
+          >
+            Paid
+          </span>
+        </dd>
+        <dd
+          class="text-right"
+        />
+      </dl>
+    </div>
+    <div
+      class="border-bottom py-3"
+    >
+      <dl>
+        <dt>
+          Items
+        </dt>
+        <dd>
+          <p
+            class="d-flex"
+          >
+            <span
+              class="mr-3"
+            >
+              1
+              ×
+            </span>
+            <span>
+              Seat in Demo Course with honor certificate
+            </span>
+          </p>
+        </dd>
+        <dt>
+          Date placed
+        </dt>
+        <dd>
+          9/30/2015
+        </dd>
+        <dt>
+          Total cost
+        </dt>
+        <dd>
+          $0.00
+        </dd>
+        <dt>
+          Order number
+        </dt>
+        <dd>
+          EDX-100784
+        </dd>
+        <dt>
+          Status
+        </dt>
+        <dd>
+          <span
+            class="badge badge-success"
+            data-testid="order-status-success"
+          >
+            Paid
+          </span>
+        </dd>
+        <dd
+          class="text-right"
+        />
+      </dl>
+    </div>
+    <div
+      class="pgn__data-table-layout-wrapper"
+    >
+      <div
+        class="pgn__data-table-layout-main"
+      >
+        <div
+          class="pgn__data-table-wrapper"
+        >
+          <div
+            class="pgn__data-table-container"
+            data-testid="data-table-container"
+          >
+            <table
+              class="pgn__data-table is-striped"
+              role="table"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    colspan="1"
+                    role="columnheader"
+                  >
+                    <span
+                      class="d-flex align-items-center"
+                    >
+                      <span>
+                        Items
+                      </span>
+                    </span>
+                  </th>
+                  <th
+                    colspan="1"
+                    role="columnheader"
+                  >
+                    <span
+                      class="d-flex align-items-center"
+                    >
+                      <span>
+                        Date placed
+                      </span>
+                    </span>
+                  </th>
+                  <th
+                    colspan="1"
+                    role="columnheader"
+                  >
+                    <span
+                      class="d-flex align-items-center"
+                    >
+                      <span>
+                        Total cost
+                      </span>
+                    </span>
+                  </th>
+                  <th
+                    colspan="1"
+                    role="columnheader"
+                  >
+                    <span
+                      class="d-flex align-items-center"
+                    >
+                      <span>
+                        Order number
+                      </span>
+                    </span>
+                  </th>
+                  <th
+                    colspan="1"
+                    role="columnheader"
+                  >
+                    <span
+                      class="d-flex align-items-center"
+                    >
+                      <span>
+                        Status
+                      </span>
+                    </span>
+                  </th>
+                  <th
+                    colspan="1"
+                    role="columnheader"
+                  >
+                    <span
+                      class="d-flex align-items-center text-right"
+                    >
+                      <span />
+                    </span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="pgn__data-table-row"
+                  role="row"
+                >
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    <p
+                      class="d-flex"
+                    >
+                      <span
+                        class="mr-3"
+                      >
+                        1
+                        ×
+                      </span>
+                      <span>
+                        Seat in Introduction to Urology with honor certificate
+                      </span>
+                    </p>
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    1/26/2016
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    $0.00
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    EDX-101706
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    <span
+                      class="badge badge-success"
+                      data-testid="order-status-success"
+                    >
+                      Paid
+                    </span>
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  />
+                </tr>
+                <tr
+                  class="pgn__data-table-row"
+                  role="row"
+                >
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    <p
+                      class="d-flex"
+                    >
+                      <span
+                        class="mr-3"
+                      >
+                        1
+                        ×
+                      </span>
+                      <span>
+                        Seat in "Dracula" by Stoker: BerkeleyX Book Club with honor certificate
+                      </span>
+                    </p>
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    12/2/2015
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    $0.00
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    EDX-101403
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    <span
+                      class="badge badge-success"
+                      data-testid="order-status-success"
+                    >
+                      Paid
+                    </span>
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  />
+                </tr>
+                <tr
+                  class="pgn__data-table-row"
+                  role="row"
+                >
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    <p
+                      class="d-flex"
+                    >
+                      <span
+                        class="mr-3"
+                      >
+                        1
+                        ×
+                      </span>
+                      <span>
+                        Seat in Demo Course with honor certificate
+                      </span>
+                    </p>
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    9/30/2015
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    $0.00
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    EDX-100784
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  >
+                    <span
+                      class="badge badge-success"
+                      data-testid="order-status-success"
+                    >
+                      Paid
+                    </span>
+                  </td>
+                  <td
+                    class="pgn__data-table-cell-wrap"
+                    role="cell"
+                  />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
     <nav
       aria-label="pagination navigation"
       class="pagination-margin pagination-default"
@@ -72,63 +510,69 @@ exports[`<OrderHistoryPage /> Renders correctly in various states renders orders
         >
           <button
             aria-label="Previous, Page 1"
-            class="previous page-link btn btn-primary"
+            class="previous page-link btn btn-tertiary"
             type="button"
           >
-            <div>
-              <span
-                class="pgn__icon"
+            <span
+              class="pgn__icon btn-icon-before"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  fill="none"
-                  focusable="false"
-                  height="24"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12l4.58-4.59Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-              Previous
-            </div>
+                <path
+                  d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12l4.58-4.59Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            Previous
           </button>
+        </li>
+        <li
+          class="page-item disabled"
+        >
+          <span
+            aria-label="Page 2, Current Page, of 10"
+            class="btn page-link page-of-count"
+          >
+            2 of 10
+          </span>
         </li>
         <li
           class="page-item"
         >
           <button
             aria-label="Next, Page 3"
-            class="next page-link btn btn-primary"
+            class="previous page-link btn btn-tertiary"
             type="button"
           >
-            <div>
-              Next
-              <span
-                class="pgn__icon"
+            Next
+            <span
+              class="pgn__icon btn-icon-after"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  fill="none"
-                  focusable="false"
-                  height="24"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6-6-6Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-            </div>
+                <path
+                  d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6-6-6Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
           </button>
         </li>
       </ul>

--- a/src/order-history/orderStatus.js
+++ b/src/order-history/orderStatus.js
@@ -1,0 +1,61 @@
+/**
+ * Order statuses, as reported by the ecommerce orders API.
+ *
+ * These are the values of `ecommerce.extensions.fulfillment.status.ORDER` and are
+ * returned verbatim by both `/api/v2/orders/` and the NAU
+ * `/payment/nau_extensions/order-payment-status/` endpoint, so the page has a
+ * single vocabulary to reason about.
+ *
+ * The pipeline ecommerce allows is:
+ *
+ *     Pending -> (Open, Payment Error)
+ *     Open    -> (Complete, Fulfillment Error)
+ *
+ * `Pending` is the status of an order whose payment has not been confirmed yet.
+ * On NAU that means a Multibanco reference the learner can still go and pay.
+ */
+export const ORDER_STATUS = {
+  PENDING: 'Pending',
+  PAYMENT_ERROR: 'Payment Error',
+  OPEN: 'Open',
+  FULFILLMENT_ERROR: 'Fulfillment Error',
+  COMPLETE: 'Complete',
+};
+
+/**
+ * Statuses that mean the money has actually been taken. `Open` and
+ * `Fulfillment Error` are paid orders whose enrolment has not completed yet, so
+ * the learner is entitled to a receipt for all three.
+ */
+const PAID_STATUSES = [
+  ORDER_STATUS.COMPLETE,
+  ORDER_STATUS.OPEN,
+  ORDER_STATUS.FULFILLMENT_ERROR,
+];
+
+export const isPaid = status => PAID_STATUSES.includes(status);
+
+/**
+ * Only `Pending` orders are worth asking the payment processor about. Resolving
+ * anything else would re-run `handle_payment` against orders that are already
+ * settled.
+ */
+export const isPending = status => status === ORDER_STATUS.PENDING;
+
+/**
+ * Map an order status onto the message used to label it and the badge variant
+ * used to colour it.
+ */
+export function statusPresentation(status) {
+  switch (status) {
+    case ORDER_STATUS.PENDING:
+      return { messageKey: 'ecommerce.order.history.status.pending', variant: 'warning' };
+    case ORDER_STATUS.PAYMENT_ERROR:
+      return { messageKey: 'ecommerce.order.history.status.failed', variant: 'danger' };
+    case ORDER_STATUS.FULFILLMENT_ERROR:
+      return { messageKey: 'ecommerce.order.history.status.fulfillment.error', variant: 'warning' };
+    default:
+      // Complete and Open are both "paid" as far as the learner is concerned.
+      return { messageKey: 'ecommerce.order.history.status.paid', variant: 'success' };
+  }
+}

--- a/src/order-history/service.js
+++ b/src/order-history/service.js
@@ -1,10 +1,43 @@
 import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
 
+const NAU_EXT_BASE_PATH = '/payment/nau_extensions';
+
+function nauExtensionsUrl(path) {
+  const { ECOMMERCE_BASE_URL } = getConfig();
+  return `${ECOMMERCE_BASE_URL}${NAU_EXT_BASE_PATH}${path}`;
+}
+
+/**
+ * Lazily resolve the payment status of a single order.
+ *
+ * Asynchronous payment methods (Multibanco references) are not confirmed while
+ * the user is in the browser, so their order is placed in the `Pending` status.
+ * This asks ecommerce to check with PayGate whether the payment has landed and,
+ * if it has, to fulfil the order. There is no background job: this is called
+ * once per pending row when the Order History page is opened.
+ *
+ * Returns the order's status, or null when the check could not be made -- in
+ * which case the row keeps the status the orders API reported.
+ */
+export async function fetchOrderPaymentStatus(orderNumber) {
+  if (!orderNumber) { return null; }
+  const httpClient = getAuthenticatedHttpClient();
+  try {
+    const { data } = await httpClient.get(
+      nauExtensionsUrl('/order-payment-status/'),
+      { params: { order_number: orderNumber } },
+    );
+    return data;
+  } catch (err) {
+    return null;
+  }
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export async function getOrders(page = 1, pageSize = 20) {
   const { ORDER_HISTORY_API_URL, RECEIPT_URL, ECOMMERCE_BASE_URL } = getConfig();
-  
+
   const ECOMMERCE_API_BASE_URL = `${ECOMMERCE_BASE_URL}/api/v2`;
   const ECOMMERCE_RECEIPT_BASE_URL = RECEIPT_URL
     ? `${RECEIPT_URL}` : `${ECOMMERCE_BASE_URL}/checkout/receipt/`;
@@ -28,6 +61,7 @@ export async function getOrders(page = 1, pageSize = 20) {
     number,
     currency,
     date_placed, // eslint-disable-line camelcase
+    status,
   }) => {
     const lineItems = lines.map(({
       title,
@@ -38,7 +72,6 @@ export async function getOrders(page = 1, pageSize = 20) {
       quantity,
       description,
     }));
-
     return {
       datePlaced: date_placed, // eslint-disable-line camelcase
       total: total_excl_tax, // eslint-disable-line camelcase
@@ -46,6 +79,7 @@ export async function getOrders(page = 1, pageSize = 20) {
       currency,
       lineItems,
       receiptUrl: `${ECOMMERCE_RECEIPT_BASE_URL}?order_number=${number}`,
+      status,
     };
   });
 

--- a/src/thank-you/ThankYouPage.jsx
+++ b/src/thank-you/ThankYouPage.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { useLocation, Link } from 'react-router-dom';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Button, Icon } from '@openedx/paragon';
+import { CheckCircle } from '@openedx/paragon/icons';
+
+import messages from './ThankYouPage.messages';
+
+/**
+ * Thank-You page reached after the PayGate "success" callback redirects the user
+ * back from the payment provider.
+ *
+ * The payment is deliberately NOT confirmed here. For an asynchronous method such
+ * as a Multibanco reference the money has not moved yet and will not for hours or
+ * days, so this page only acknowledges the order and points the user at the Order
+ * History page, where each pending order is resolved against PayGate when the page
+ * is opened.
+ *
+ * The order number is passed by `PayGateCallbackSuccessResponseView` through the
+ * `order_number` query string parameter.
+ */
+const ThankYouPage = () => {
+  const { formatMessage } = useIntl();
+  const params = new URLSearchParams(useLocation().search);
+  const orderNumber = params.get('order_number');
+
+  return (
+    <div
+      className="page__thank-you container-fluid py-5 d-flex justify-content-center"
+      data-testid="thank-you-page"
+    >
+      <section className="thank-you text-center p-4">
+        <Icon src={CheckCircle} className="thank-you__icon text-success mx-auto mb-3" size="lg" />
+
+        <h1 className="mb-3">
+          {formatMessage(messages['ecommerce.thank.you.page.heading'])}
+        </h1>
+
+        <p className="lead mb-3">
+          {formatMessage(messages['ecommerce.thank.you.page.body'])}
+        </p>
+
+        <p className="mb-4">
+          {formatMessage(messages['ecommerce.thank.you.page.body.async'])}
+        </p>
+
+        {orderNumber && (
+          <p data-testid="thank-you-order-number" className="mb-4 text-muted">
+            {formatMessage(
+              messages['ecommerce.thank.you.page.order.number'],
+              { orderNumber },
+            )}
+          </p>
+        )}
+
+        <Button
+          as={Link}
+          to="/orders"
+          variant="primary"
+          data-testid="thank-you-my-orders-button"
+          className="px-5"
+        >
+          {formatMessage(messages['ecommerce.thank.you.page.button.my.orders'])}
+        </Button>
+      </section>
+    </div>
+  );
+};
+
+export default ThankYouPage;

--- a/src/thank-you/ThankYouPage.messages.js
+++ b/src/thank-you/ThankYouPage.messages.js
@@ -1,0 +1,38 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  'ecommerce.thank.you.page.heading': {
+    id: 'ecommerce.thank.you.page.heading',
+    defaultMessage: 'Thank you for your order!',
+    description: 'Heading shown on the thank-you page after an order is placed.',
+  },
+  'ecommerce.thank.you.page.body': {
+    id: 'ecommerce.thank.you.page.body',
+    defaultMessage: 'We have received your order and are processing it.',
+    description: 'Main body text of the thank-you page.',
+  },
+  'ecommerce.thank.you.page.body.async': {
+    id: 'ecommerce.thank.you.page.body.async',
+    defaultMessage:
+      'If you chose to pay by Multibanco reference, your enrolment is confirmed '
+      + 'once the payment is made. You can follow the status of your order on the '
+      + 'order history page.',
+    description:
+      'Explains to the user that a Multibanco reference payment is confirmed only '
+      + 'after it is actually paid, and where to check the status.',
+  },
+  'ecommerce.thank.you.page.button.my.orders': {
+    id: 'ecommerce.thank.you.page.button.my.orders',
+    defaultMessage: 'My orders',
+    description:
+      'Label of the button on the thank-you page that takes the user to the '
+      + 'order history page.',
+  },
+  'ecommerce.thank.you.page.order.number': {
+    id: 'ecommerce.thank.you.page.order.number',
+    defaultMessage: 'Order number: {orderNumber}',
+    description: 'Order number shown on the thank-you page.',
+  },
+});
+
+export default messages;

--- a/src/thank-you/ThankYouPage.test.jsx
+++ b/src/thank-you/ThankYouPage.test.jsx
@@ -1,0 +1,49 @@
+/* eslint-disable global-require, react/jsx-filename-extension */
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { render, screen } from '../testing';
+import ThankYouPage from './ThankYouPage';
+
+describe('<ThankYouPage />', () => {
+  const renderAt = (path) => render(
+    <MemoryRouter initialEntries={[path]}>
+      <ThankYouPage />
+    </MemoryRouter>,
+  );
+
+  it('renders the heading, the body and a "My orders" button linking to /orders', () => {
+    renderAt('/thank-you');
+
+    expect(
+      screen.getByRole('heading', { name: /thank you for your order/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/we have received your order/i)).toBeInTheDocument();
+    // The confirmation icon is rendered.
+    expect(document.querySelector('svg')).toBeInTheDocument();
+    // The "My orders" button points to the order history page.
+    const button = screen.getByTestId('thank-you-my-orders-button');
+    expect(button).toHaveAttribute('href', '/orders');
+    expect(button).toHaveTextContent(/my orders/i);
+  });
+
+  it('tells the user that a Multibanco reference is confirmed only once paid', () => {
+    renderAt('/thank-you');
+
+    expect(screen.getByText(/multibanco reference/i)).toBeInTheDocument();
+    expect(screen.getByText(/order history page/i)).toBeInTheDocument();
+  });
+
+  it('displays the order number when present in the URL query string', () => {
+    renderAt('/thank-you?order_number=OPENEDX-100120');
+
+    const orderNumberNode = screen.getByTestId('thank-you-order-number');
+    expect(orderNumberNode).toHaveTextContent('OPENEDX-100120');
+  });
+
+  it('does not render the order number node when absent', () => {
+    renderAt('/thank-you');
+
+    expect(screen.queryByTestId('thank-you-order-number')).toBeNull();
+  });
+});

--- a/src/thank-you/index.js
+++ b/src/thank-you/index.js
@@ -1,0 +1,3 @@
+import ThankYouPage from './ThankYouPage';
+
+export default ThankYouPage;


### PR DESCRIPTION
### Context

When the user clicks **Continuar** on PayGate for asynchronous payment methods (Multibanco references, MBWAY), the payment is **not** confirmed at that moment — and will not be for hours or days. The previous flow tried to resolve the payment synchronously on the success callback, which raised `GatewayError` and showed a misleading **"You have not been charged."** page, even when PayGate would later confirm the payment.

The chosen solution avoids background jobs and polling entirely:

1. PayGate's success callback redirects to a new **Thank-You page** in this MFE.
2. That page sends the user to the existing **Order History** page.
3. Order History **lazily** asks ecommerce about each `Pending` order, once, on render. If PayGate has meanwhile received the money, the order is fulfilled server-side during that call and the row flips to `Paid`. Orders still awaiting payment keep a clear badge instead of being hidden or wrongly reported as failed.

This PR is the **frontend** part. The backend ships in the companion PRs listed at the bottom.

### What this PR adds

#### Thank-You page

- **`src/thank-you/ThankYouPage.jsx`** — New page reached after the PayGate success callback. Reads the `order_number` query parameter (passed by `PayGateCallbackSuccessResponseView`), and shows a success icon, a heading, an explanatory body noting that some payment methods are confirmed asynchronously, the order number when present, and a primary **"My orders"** Paragon `Button` linking to `/orders`.
- **`src/thank-you/ThankYouPage.messages.js`** — New i18n messages for the heading, body, asynchronous-payment note, order-number line and button label.
- **`src/thank-you/index.js`** — Public re-export.
- **`src/index.jsx`** — Registers the `/thank-you` route alongside the existing `/orders` route.

<img width="1245" height="647" alt="image" src="https://github.com/user-attachments/assets/564901a9-086f-4cb4-8679-0c8e1bb67ca5" />

#### Order status vocabulary

- **`src/order-history/orderStatus.js`** (new) — Single source of truth for order statuses, using the values ecommerce actually returns (`ecommerce.extensions.fulfillment.status.ORDER`), rather than a parallel frontend vocabulary:

  | Status | Meaning | Badge |
  |---|---|---|
  | `Pending` | Payment not confirmed — e.g. an unpaid Multibanco reference | `Awaiting payment` (warning) |
  | `Payment Error` | Payment failed | `Payment failed` (danger) |
  | `Open` | Paid, enrolment in progress | `Paid` (success) |
  | `Fulfillment Error` | Paid, but enrolment did not complete | `Paid, enrolment pending` (warning) |
  | `Complete` | Paid and enrolled | `Paid` (success) |

  It exports `isPaid()` — true for `Complete`, `Open` and `Fulfillment Error`, since the learner is entitled to a receipt in all three — and `isPending()`, which is true only for `Pending`. Restricting resolution to `Pending` matters: asking about any other status would re-run `handle_payment` against an order that is already settled.

#### Order History — lazy resolution and a Status column

- **`service.js`** — Adds `fetchOrderPaymentStatus(orderNumber)`, calling `GET /payment/nau_extensions/order-payment-status/?order_number=…`. It returns `null` on any failure so that a backend error leaves the row on the status the orders API already reported, rather than blanking or misreporting it. `getOrders()` now also passes the order's `status` through to the table.
- **`OrderHistoryPage.jsx`**:
  - Adds `statusOverrides` state, keyed by order number, so a resolved status supersedes the one from the orders API without refetching the page.
  - `resolvePendingOrders()` runs on mount and whenever the `orders` prop changes. It filters to `Pending` rows only and calls `fetchOrderPaymentStatus` once per row. This is the **only** place PayGate is consulted, and only while the user is on the page — no polling, no background job.
  - New **Status** column rendering a Paragon `Badge` whose label and variant come from `statusPresentation()` (`data-testid="order-status-<variant>"` for tests).
  - The receipt link is now gated on `isPaid(status)`, so unpaid orders no longer offer a receipt.
  - The mobile card view shows the same Status field.
- **`OrderHistoryPage.messages.jsx`** — New messages for the `Status` column header and the four status labels.

<img width="1913" height="234" alt="image" src="https://github.com/user-attachments/assets/e3920730-3ed6-49ae-b87a-2ec66ec87f89" />

### User flow after this PR

1. User clicks **Continuar** on PayGate → PayGate redirects to its success callback.
2. The success callback (paygate PR) redirects to `<MFE>/thank-you?order_number=<basket.order_number>`.
3. The **Thank-You page** appears with the order number and a **"My orders"** button.
4. **"My orders"** navigates to `/orders`.
5. Every `Pending` row is resolved once against `OrderPaymentStatusView`. Confirmed payments are fulfilled server-side and flip to `Paid`; unpaid references keep **Awaiting payment**; failures show **Payment failed**.
6. Paid rows expose the existing receipt link.

### Related PRs

Merge order: both backend PRs first, then this one, then re-pin in `nau-tutor-configs`.

- ecommerce-plugin-paygate: https://github.com/fccn/ecommerce-plugin-paygate/pull/27
- ecommerce-nau-extensions: https://github.com/fccn/ecommerce-nau-extensions/pull/37

Related to: https://github.com/fccn/nau-technical/issues/923
